### PR TITLE
Add missing hook to config validation

### DIFF
--- a/lib/cf_deployer/config_validation.rb
+++ b/lib/cf_deployer/config_validation.rb
@@ -6,7 +6,7 @@ module CfDeployer
 
     CommonInputs = [:application, :environment, :component, :region]
     EnvironmentOptions = [:settings, :inputs, :tags, :components]
-    ComponentOptions = [:settings, :inputs, :tags, :'depends-on', :'deployment-strategy', :'before-destroy', :'after-create', :'after-swap', :'defined_outputs', :'defined_parameters', :config_dir, :capabilities, :notify]
+    ComponentOptions = [:settings, :inputs, :tags, :'depends-on', :'deployment-strategy', :'before-destroy', :'after-create', :'after-swap', :'after-update', :'defined_outputs', :'defined_parameters', :config_dir, :capabilities, :notify]
 
     def validate config, validate_inputs = true
       @config = config


### PR DESCRIPTION
A new after-update hook was created after config_validation - config_validation was never updated to allow this new hook, so attempts to use the hook simply fail.