### PR TITLE
HealthCheck Resilience

### DIFF
--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -53,11 +53,16 @@ module CfDeployer
       private
 
       def healthy_instance_count
-        count = auto_scaling_instances.count do |instance|
-          instance.health_status == 'HEALTHY' && (load_balancers.empty? || instance_in_service?( instance.ec2_instance ))
+        begin
+          count = auto_scaling_instances.count do |instance|
+            instance.health_status == 'HEALTHY' && (load_balancers.empty? || instance_in_service?( instance.ec2_instance ))
+          end
+          Log.info "Healthy instance count: #{count}"
+          count
+        rescue => e
+          Log.info "Unable to determine healthy instance count due to error: #{e.message}"
+          -1
         end
-        Log.info "Healthy instance count: #{count}"
-        count
       end
 
       def instance_in_service? instance

--- a/spec/unit/driver/auto_scaling_group_spec.rb
+++ b/spec/unit/driver/auto_scaling_group_spec.rb
@@ -57,6 +57,13 @@ describe 'Autoscaling group driver' do
       expect(@driver.send(:healthy_instance_count)).to eql 4
     end
 
+    it 'health check should be resilient against intermittent errors' do
+      instance5 = double('instance5')
+      expect(instance5).to receive(:health_status).and_raise(StandardError)
+      allow(group).to receive(:auto_scaling_instances){ [ instance5 ] }
+      expect(@driver.send(:healthy_instance_count)).to eql -1
+    end
+
     context 'when an elb is associated with the auto scaling group' do
       it 'should not include instances that are HEALTHY but not associated with the elb' do
         instance_collection = double('instance_collection', :health => [{:instance => ec2_instance1, :state => 'InService'}])


### PR DESCRIPTION
There's a timing issue in the health check loop.  At the time that auto_scaling_instances.count is executed, an instance in the list may be terminated due to a failing health check (or any other reason).  In the block of the loop, we check the instances health_status, and ec2_instance.  These calls can fail if the instance no longer exists, causing the entire deployment to fail.  The terminated instance is a transient error - had it been terminated immediately before or after auto_scaling_instances.count, the deployment would behave exactly as expected.

Rescue any such transient error, report it to the user, and allow the health check to continue.  If the error is not transient, then the overall deployment timeout should prevent the block from continuing.