### PR TITLE
Increase AWS-SDK retries

### DIFF
--- a/lib/cf_deployer.rb
+++ b/lib/cf_deployer.rb
@@ -38,7 +38,7 @@ require_relative 'cf_deployer/defaults'
 
 module CfDeployer
 
-  AWS.config(:max_retries => 5)
+  AWS.config(:max_retries => 20)
 
   def self.config opts
     config = self.parseconfig opts, false


### PR DESCRIPTION
We set a hard limit of AWS-SDK retries to 5.  We're using the aws-sdk-v1, and do not memoize calls - setting logging to debug shows that we make a *very* large number of repeated calls, especially during health_checks for application that have a high number of instances (2 * number_of_instance * health_check_iteration).  Deployments often fail because we frequently max out the number of AWS retries.

Increase the default number of retries to reduce the likelihood of failures.

Long term fixes for later: 
    - make retries configurable
    - rewrite the health_check to reduce the number of calls to aws-sdk
    - use AWS.memoize in areas where we repeatedly make the same request
    - check AWS-SDK v2 to see if this sort of problem is addressable in other ways.