### PR TITLE
Update sample apps - default to a single AZ

### DIFF
--- a/samples/cname-swap/web.json
+++ b/samples/cname-swap/web.json
@@ -30,8 +30,12 @@
       "Default": "0.0.0.0/0",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
-   }
-
+    },
+    "AvailabilityZone" : {
+      "Description" : "The availability zone where EC2 instances are created",
+      "Type": "String",
+      "Default": "us-east-1c"
+    }
   },
 
   "Mappings" : {
@@ -66,7 +70,7 @@
     "WebServerGroup" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
-        "AvailabilityZones" : { "Fn::GetAZs" : "" },
+        "AvailabilityZones" : [ { "Ref" : "AvailabilityZone" } ],
         "LaunchConfigurationName" : { "Ref" : "LaunchConfig" },
         "MinSize" : "1",
         "MaxSize" : "1",
@@ -104,7 +108,7 @@
     "ElasticLoadBalancer" : {
       "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties" : {
-        "AvailabilityZones" : { "Fn::GetAZs" : "" },
+        "AvailabilityZones" : [ { "Ref" : "AvailabilityZone" } ],
         "Listeners" : [ {
           "LoadBalancerPort" : "80",
           "InstancePort" : { "Ref" : "WebServerPort" },

--- a/samples/create-or-update/web.json
+++ b/samples/create-or-update/web.json
@@ -30,8 +30,12 @@
       "Default": "0.0.0.0/0",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
-   }
-
+    },
+    "AvailabilityZone" : {
+      "Description" : "The availability zone where EC2 instances are created",
+      "Type": "String",
+      "Default": "us-east-1c"
+    }
   },
 
   "Mappings" : {
@@ -66,7 +70,7 @@
     "WebServerGroup" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
-        "AvailabilityZones" : { "Fn::GetAZs" : "" },
+        "AvailabilityZones" : [ { "Ref" : "AvailabilityZone" } ],
         "LaunchConfigurationName" : { "Ref" : "LaunchConfig" },
         "MinSize" : "1",
         "MaxSize" : "1",
@@ -102,7 +106,7 @@
     "ElasticLoadBalancer" : {
       "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties" : {
-        "AvailabilityZones" : { "Fn::GetAZs" : "" },
+        "AvailabilityZones" : [ { "Ref" : "AvailabilityZone" } ],
         "Listeners" : [ {
           "LoadBalancerPort" : "80",
           "InstancePort" : { "Ref" : "WebServerPort" },

--- a/samples/multi-asg-swap/web.json
+++ b/samples/multi-asg-swap/web.json
@@ -30,8 +30,12 @@
       "Default": "0.0.0.0/0",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
-   }
-    
+    },
+    "AvailabilityZone" : {
+      "Description" : "The availability zone where EC2 instances are created",
+      "Type": "String",
+      "Default": "us-east-1c"
+    }
   },
 
   "Mappings" : {
@@ -66,7 +70,7 @@
     "WebServerGroup1" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
-        "AvailabilityZones" : { "Fn::GetAZs" : "" },
+        "AvailabilityZones" : [ { "Ref" : "AvailabilityZone" } ],
         "LaunchConfigurationName" : { "Ref" : "LaunchConfig" },
         "MinSize" : "3",
         "MaxSize" : "5",
@@ -87,7 +91,7 @@
     "WebServerGroup2" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
-        "AvailabilityZones" : { "Fn::GetAZs" : "" },
+        "AvailabilityZones" : [ { "Ref" : "AvailabilityZone" } ],
         "LaunchConfigurationName" : { "Ref" : "LaunchConfig" },
         "MinSize" : "1",
         "MaxSize" : "10",

--- a/samples/simple/base.json
+++ b/samples/simple/base.json
@@ -8,13 +8,18 @@
       "Description": "TCP/IP port of the web server",
       "Type": "String",
       "Default": "8000"
+    },
+    "AvailabilityZone" : {
+      "Description" : "The availability zone where EC2 instances are created",
+      "Type": "String",
+      "Default": "us-east-1c"
     }
   },
   "Resources" : {
     "ElasticLoadBalancer": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
-        "AvailabilityZones": { "Fn::GetAZs": "" },
+        "AvailabilityZones" : [ { "Ref" : "AvailabilityZone" } ],
         "Listeners": [ {
           "LoadBalancerPort": "80",
           "InstancePort": {

--- a/samples/simple/web.json
+++ b/samples/simple/web.json
@@ -20,6 +20,11 @@
     "ElasticLoadBalancer": {
       "Description": "Name of existing ELB",
       "Type": "String"
+    },
+    "AvailabilityZone" : {
+      "Description" : "The availability zone where EC2 instances are created",
+      "Type": "String",
+      "Default": "us-east-1c"
     }
   },
   "Mappings"  : {
@@ -47,9 +52,7 @@
       },
 
       "Properties": {
-        "AvailabilityZones": {
-          "Fn::GetAZs": ""
-        },
+        "AvailabilityZones" : [ { "Ref" : "AvailabilityZone" } ],
         "LaunchConfigurationName": {
           "Ref": "LaunchConfig"
         },


### PR DESCRIPTION
There are multiple AZs in a single region, and some of them conflict (you can't have instances in both us-east-1a, and us-east-1b).  The sample apps can fail if instances are spun up across conflicting AZ's. 

Default the sample apps to a single AZ, but allow the user to override.