### PR TITLE
Wire up travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.7
+  - 2.2.3
+  - ruby-head
+  - jruby-19mode
+  - jruby-9.0.1.0
+  - rbx-2
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: rbx-2
+    - rvm: jruby-9.0.1.0
+  fast_finish: true
+script:
+  - bundle exec rake

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/cf_deployer.svg)](https://badge.fury.io/rb/cf_deployer)
+[![Build Status](https://travis-ci.org/manheim/cf_deployer.svg?branch=master)](https://travis-ci.org/manheim/cf_deployer)
 [![Code Climate](https://codeclimate.com/github/manheim/cf_deployer/badges/gpa.svg)](https://codeclimate.com/github/manheim/cf_deployer)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 


### PR DESCRIPTION
Someone with admin rights (@kmao, @bryantidd) will need to enable `cf_deployer` on [Travis CI](https://travis-ci.org/profile/manheim).

