### PR TITLE
Fix broken Travis test for ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
   - jruby-19mode
   - jruby-9.0.1.0
   - rbx-2
+before_install:
+  - gem install bundler
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -52,3 +52,4 @@ version 1.3.9
 
 version 1.4.0
   - Added support for stack policies (https://github.com/manheim/cf_deployer/pull/40)
+  - Fix broken Travis builds with newer version of bundler (https://github.com/manheim/cf_deployer/pull/42)


### PR DESCRIPTION
This seems to be a known issue with Travis.  The work around is to install a newer version of bundler.

https://github.com/travis-ci/travis-ci/issues/5239