### PR TITLE
Issue 38 fail rollbacks

### DIFF
--- a/lib/cf_deployer/driver/cloud_formation_driver.rb
+++ b/lib/cf_deployer/driver/cloud_formation_driver.rb
@@ -21,13 +21,18 @@ module CfDeployer
           CfDeployer::Driver::DryRun.guard "Skipping update_stack" do
             aws_stack.update opts.merge(:template => template)
           end
+
+          return !CfDeployer::Driver::DryRun.enabled?
         rescue AWS::CloudFormation::Errors::ValidationError => e
           if e.message =~ /No updates are to be performed/
             Log.info e.message
+            return false
           else
             raise
           end
         end
+
+        true
       end
 
       def stack_status

--- a/lib/cf_deployer/driver/dry_run.rb
+++ b/lib/cf_deployer/driver/dry_run.rb
@@ -4,6 +4,30 @@ module CfDeployer
 
       @@enabled = false
 
+      def self.enabled?
+        @@enabled
+      end
+
+      def self.run_with_value value, &block
+        previous_value = @@enabled
+        @@enabled = value
+        begin
+          block.call
+        rescue => e
+          raise e
+        ensure
+          @@enabled = previous_value
+        end
+      end
+
+      def self.enable_for &block
+        run_with_value(true, &block)
+      end
+
+      def self.disable_for &block
+        run_with_value(false, &block)
+      end
+
       def self.enable
         CfDeployer::Log.info "Enabling Dry-Run Mode"
         @@enabled = true

--- a/lib/cf_deployer/stack.rb
+++ b/lib/cf_deployer/stack.rb
@@ -3,9 +3,9 @@ module CfDeployer
   end
 
   class Stack
-    SUCCESS_STATS = [:create_complete, :update_complete, :update_rollback_complete, :delete_complete]
+    SUCCESS_STATS = [:create_complete, :update_complete, :delete_complete]
     READY_STATS = SUCCESS_STATS - [:delete_complete]
-    FAILED_STATS = [:create_failed, :update_failed, :delete_failed]
+    FAILED_STATS = [:create_failed, :update_failed, :delete_failed, :update_rollback_complete]
 
 
     def initialize(stack_name, component, context)

--- a/lib/cf_deployer/stack.rb
+++ b/lib/cf_deployer/stack.rb
@@ -127,8 +127,8 @@ module CfDeployer
       unless override_policy_json.nil?
         args[:stack_policy_during_update_body] = override_policy_json
       end
-      @cf_driver.update_stack(template, args)
-      wait_for_stack_op_terminate
+      stack_updated = @cf_driver.update_stack(template, args)
+      wait_for_stack_op_terminate if stack_updated
     end
 
     def create_stack(template, params, capabilities, tags, notify, create_policy_json)

--- a/spec/unit/driver/dry_run_spec.rb
+++ b/spec/unit/driver/dry_run_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe 'DryRun' do
+
+  context 'enable_for' do
+    it 'enables dry run only during the block given' do
+      CfDeployer::Driver::DryRun.disable_for do
+        enabled_in_block = false
+
+        CfDeployer::Driver::DryRun.enable_for do
+          enabled_in_block = CfDeployer::Driver::DryRun.enabled?
+        end
+
+        expect(enabled_in_block).to be_true
+        expect(CfDeployer::Driver::DryRun.enabled?).to be_false
+      end
+    end
+
+    it 'resets dry run, even if the given block throws an exception' do
+      CfDeployer::Driver::DryRun.disable_for do
+        enabled_in_block = false
+
+        expect do
+          CfDeployer::Driver::DryRun.enable_for do
+            enabled_in_block = CfDeployer::Driver::DryRun.enabled?
+            raise 'boom'
+          end
+        end.to raise_error('boom')
+
+        expect(enabled_in_block).to be_true
+        expect(CfDeployer::Driver::DryRun.enabled?).to be_false
+      end
+    end
+  end
+
+  context 'disable_for' do
+    it 'disables dry run only during the block given' do
+      CfDeployer::Driver::DryRun.enable_for do
+        enabled_in_block = nil
+
+        CfDeployer::Driver::DryRun.disable_for do
+          enabled_in_block = CfDeployer::Driver::DryRun.enabled?
+        end
+
+        expect(enabled_in_block).to be_false
+        expect(CfDeployer::Driver::DryRun.enabled?).to be_true
+      end
+    end
+
+    it 'resets dry run, even if the given block throws an exception' do
+      CfDeployer::Driver::DryRun.enable_for do
+        enabled_in_block = nil
+
+        expect do
+          CfDeployer::Driver::DryRun.disable_for do
+            enabled_in_block = CfDeployer::Driver::DryRun.enabled?
+            raise 'boom'
+          end
+        end.to raise_error('boom')
+
+        expect(enabled_in_block).to be_false
+        expect(CfDeployer::Driver::DryRun.enabled?).to be_true
+      end
+    end
+  end
+end

--- a/spec/unit/stack_spec.rb
+++ b/spec/unit/stack_spec.rb
@@ -102,6 +102,20 @@ describe CfDeployer::Stack do
       stack.deploy
     end
 
+    it 'does not fail if deployment caused no updates, and stack was already in a rollback state' do
+      template = { :resources => {}}
+      allow(CfDeployer::ConfigLoader).to receive(:erb_to_json).with('web', @config).and_return(template)
+      allow(@cf_driver).to receive(:stack_exists?) { true }
+      allow(@cf_driver).to receive(:stack_status) { :update_rollback_complete }
+      expected_opt = {
+        :capabilities => [],
+        :parameters => {:foo => 'bar'}
+      }
+      expect(@cf_driver).to receive(:update_stack).with(template, expected_opt).and_return(false)
+      stack = CfDeployer::Stack.new('test','web', @config)
+      stack.deploy
+    end
+
     it 'updates a stack using the override policy, when defined' do
       template = { :resources => {}}
       override_policy = { :Statement => [] }


### PR DESCRIPTION
Treat automatic stack rollbacks as a failure (the intended deployment/change did not succeed).