### PR TITLE
Issue #32 - ASG Deployment Strategy: improve warm up for desired instances

### DIFF
--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -59,7 +59,7 @@ module CfDeployer
       end
 
       def desired_capacity_reached? number
-        healthy_instance_count == number
+        healthy_instance_count >= number
       end
 
       private

--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -52,10 +52,14 @@ module CfDeployer
 
       def wait_for_desired_capacity number
         Timeout::timeout(@timeout){
-          while healthy_instance_count != number
+          until desired_capacity_reached?(number)
             sleep 15
           end
         }
+      end
+
+      def desired_capacity_reached? number
+        healthy_instance_count == number
       end
 
       private

--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -50,6 +50,14 @@ module CfDeployer
         instance_info
       end
 
+      def wait_for_desired_capacity number
+        Timeout::timeout(@timeout){
+          while healthy_instance_count != number
+            sleep 15
+          end
+        }
+      end
+
       private
 
       def healthy_instance_count
@@ -71,14 +79,6 @@ module CfDeployer
             health[:instance] == instance ? health[:state] == 'InService' : false
           end
         end
-      end
-
-      def wait_for_desired_capacity number
-        Timeout::timeout(@timeout){
-          while healthy_instance_count != number
-            sleep 15
-          end
-        }
       end
 
       def aws_group

--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -23,7 +23,7 @@ module CfDeployer
 
         CfDeployer::Driver::DryRun.guard "Skipping ASG warmup" do
           aws_group.set_desired_capacity desired
-          wait_for_healthy_instance desired
+          wait_for_desired_capacity desired
         end
       end
 
@@ -73,7 +73,7 @@ module CfDeployer
         end
       end
 
-      def wait_for_healthy_instance number
+      def wait_for_desired_capacity number
         Timeout::timeout(@timeout){
           while healthy_instance_count != number
             sleep 15

--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -3,7 +3,7 @@ module CfDeployer
     class AutoScalingGroup
       extend Forwardable
 
-      def_delegators :aws_group, :auto_scaling_instances, :ec2_instances, :load_balancers
+      def_delegators :aws_group, :auto_scaling_instances, :ec2_instances, :load_balancers, :desired_capacity
 
       attr_reader :group_name, :group
 
@@ -23,7 +23,7 @@ module CfDeployer
 
         CfDeployer::Driver::DryRun.guard "Skipping ASG warmup" do
           aws_group.set_desired_capacity desired
-          wait_for_desired_capacity desired
+          wait_for_desired_capacity
         end
       end
 
@@ -50,16 +50,16 @@ module CfDeployer
         instance_info
       end
 
-      def wait_for_desired_capacity number
+      def wait_for_desired_capacity
         Timeout::timeout(@timeout){
-          until desired_capacity_reached?(number)
+          until desired_capacity_reached?
             sleep 15
           end
         }
       end
 
-      def desired_capacity_reached? number
-        healthy_instance_count >= number
+      def desired_capacity_reached?
+        healthy_instance_count >= desired_capacity
       end
 
       private

--- a/spec/unit/driver/auto_scaling_group_spec.rb
+++ b/spec/unit/driver/auto_scaling_group_spec.rb
@@ -133,25 +133,44 @@ describe 'Autoscaling group driver' do
   end
 
   describe '#wait_for_desired_capacity' do
-    it 'completes if healthy instance count matches desired capacity' do
+    it 'completes if desired capacity reached' do
       expected_number = 5
-      expect(@driver).to receive(:healthy_instance_count).and_return(expected_number)
+      expect(@driver).to receive(:desired_capacity_reached?).with(expected_number).and_return(true)
 
       @driver.wait_for_desired_capacity(expected_number)
     end
 
-    it 'times out if healthy instance count is less than desired capacity' do
+    it 'times out if desired capacity is not reached' do
       expected_number = 5
-      expect(@driver).to receive(:healthy_instance_count).and_return(expected_number - 1)
+      expect(@driver).to receive(:desired_capacity_reached?).with(expected_number).and_return(false)
 
       expect { @driver.wait_for_desired_capacity(expected_number) }.to raise_error(Timeout::Error)
     end
+  end
 
-    it 'times out if healthy instance count is more than desired capacity' do
+  describe '#desired_capacity_reached?' do
+    it 'returns true if healthy instance count matches desired capacity' do
       expected_number = 5
+
+      expect(@driver).to receive(:healthy_instance_count).and_return(expected_number)
+
+      expect(@driver.desired_capacity_reached?(expected_number)).to be_true
+    end
+
+    it 'returns false if healthy instance count is less than desired capacity' do
+      expected_number = 5
+
+      expect(@driver).to receive(:healthy_instance_count).and_return(expected_number - 1)
+
+      expect(@driver.desired_capacity_reached?(expected_number)).to be_false
+    end
+
+    it 'returns false if healthy instance count is more than desired capacity' do
+      expected_number = 5
+
       expect(@driver).to receive(:healthy_instance_count).and_return(expected_number + 1)
 
-      expect { @driver.wait_for_desired_capacity(expected_number) }.to raise_error(Timeout::Error)
+      expect(@driver.desired_capacity_reached?(expected_number)).to be_false
     end
   end
 end

--- a/spec/unit/driver/auto_scaling_group_spec.rb
+++ b/spec/unit/driver/auto_scaling_group_spec.rb
@@ -131,4 +131,27 @@ describe 'Autoscaling group driver' do
       expect(@driver.instance_statuses).to eq( { 'i-abcd1234' => returned_status } )
     end
   end
+
+  describe '#wait_for_desired_capacity' do
+    it 'completes if healthy instance count matches desired capacity' do
+      expected_number = 5
+      expect(@driver).to receive(:healthy_instance_count).and_return(expected_number)
+
+      @driver.wait_for_desired_capacity(expected_number)
+    end
+
+    it 'times out if healthy instance count is less than desired capacity' do
+      expected_number = 5
+      expect(@driver).to receive(:healthy_instance_count).and_return(expected_number - 1)
+
+      expect { @driver.wait_for_desired_capacity(expected_number) }.to raise_error(Timeout::Error)
+    end
+
+    it 'times out if healthy instance count is more than desired capacity' do
+      expected_number = 5
+      expect(@driver).to receive(:healthy_instance_count).and_return(expected_number + 1)
+
+      expect { @driver.wait_for_desired_capacity(expected_number) }.to raise_error(Timeout::Error)
+    end
+  end
 end

--- a/spec/unit/driver/auto_scaling_group_spec.rb
+++ b/spec/unit/driver/auto_scaling_group_spec.rb
@@ -165,12 +165,12 @@ describe 'Autoscaling group driver' do
       expect(@driver.desired_capacity_reached?(expected_number)).to be_false
     end
 
-    it 'returns false if healthy instance count is more than desired capacity' do
+    it 'returns true if healthy instance count is more than desired capacity' do
       expected_number = 5
 
       expect(@driver).to receive(:healthy_instance_count).and_return(expected_number + 1)
 
-      expect(@driver.desired_capacity_reached?(expected_number)).to be_false
+      expect(@driver.desired_capacity_reached?(expected_number)).to be_true
     end
   end
 end

--- a/spec/unit/driver/auto_scaling_group_spec.rb
+++ b/spec/unit/driver/auto_scaling_group_spec.rb
@@ -29,23 +29,27 @@ describe 'Autoscaling group driver' do
     it 'should warm up the group to the desired size' do
       expect(group).to receive(:auto_scaling_instances){[instance1, instance2]}
       expect(group).to receive(:set_desired_capacity).with(2)
+      expect(group).to receive(:desired_capacity).and_return(2)
       @driver.warm_up 2
     end
 
     it 'should wait for the warm up of the group even if desired is the same as the minimum' do
       expect(group).to receive(:auto_scaling_instances){[instance2]}
       expect(group).to receive(:set_desired_capacity).with(1)
+      expect(group).to receive(:desired_capacity).and_return(1)
       @driver.warm_up 1
     end
 
     it 'should ignore warming up if desired number is less than min size of the group' do
       expect(group).not_to receive(:set_desired_capacity)
+      expect(group).not_to receive(:desired_capacity)
       @driver.warm_up 0
     end
 
     it 'should warm up to maximum if desired number is greater than maximum size of group' do
       expect(group).to receive(:auto_scaling_instances){[instance1, instance2, instance3, instance4]}
       expect(group).to receive(:set_desired_capacity).with(4)
+      expect(group).to receive(:desired_capacity).and_return(4)
       @driver.warm_up 5
     end
   end
@@ -134,17 +138,15 @@ describe 'Autoscaling group driver' do
 
   describe '#wait_for_desired_capacity' do
     it 'completes if desired capacity reached' do
-      expected_number = 5
-      expect(@driver).to receive(:desired_capacity_reached?).with(expected_number).and_return(true)
+      expect(@driver).to receive(:desired_capacity_reached?).and_return(true)
 
-      @driver.wait_for_desired_capacity(expected_number)
+      @driver.wait_for_desired_capacity
     end
 
     it 'times out if desired capacity is not reached' do
-      expected_number = 5
-      expect(@driver).to receive(:desired_capacity_reached?).with(expected_number).and_return(false)
+      expect(@driver).to receive(:desired_capacity_reached?).and_return(false)
 
-      expect { @driver.wait_for_desired_capacity(expected_number) }.to raise_error(Timeout::Error)
+      expect { @driver.wait_for_desired_capacity }.to raise_error(Timeout::Error)
     end
   end
 
@@ -152,25 +154,28 @@ describe 'Autoscaling group driver' do
     it 'returns true if healthy instance count matches desired capacity' do
       expected_number = 5
 
+      expect(group).to receive(:desired_capacity).and_return(expected_number)
       expect(@driver).to receive(:healthy_instance_count).and_return(expected_number)
 
-      expect(@driver.desired_capacity_reached?(expected_number)).to be_true
+      expect(@driver.desired_capacity_reached?).to be_true
     end
 
     it 'returns false if healthy instance count is less than desired capacity' do
       expected_number = 5
 
+      expect(group).to receive(:desired_capacity).and_return(expected_number)
       expect(@driver).to receive(:healthy_instance_count).and_return(expected_number - 1)
 
-      expect(@driver.desired_capacity_reached?(expected_number)).to be_false
+      expect(@driver.desired_capacity_reached?).to be_false
     end
 
     it 'returns true if healthy instance count is more than desired capacity' do
       expected_number = 5
 
+      expect(group).to receive(:desired_capacity).and_return(expected_number)
       expect(@driver).to receive(:healthy_instance_count).and_return(expected_number + 1)
 
-      expect(@driver.desired_capacity_reached?(expected_number)).to be_true
+      expect(@driver.desired_capacity_reached?).to be_true
     end
   end
 end


### PR DESCRIPTION
Background: We wait for exactly the expected number of instances while warming up instances for a newly deployed AutoScalingGroup.  If we end up with more than our desired number of instances, we count that as a failure, when in fact having more instances is an acceptable outcome.  If the number of desired instances changes during a deployment (due to autoscaling), we do not adjust our expectation, which can also lead to a failure.

This pull request accounts for those two scenarios - warmup is now considered successful if we have at least as many desired instances as requested (if exactly the number of instances can handle the current load, certainly more instances can also handle the current load), and warmup now takes into account a change in the number of desired instances while deploying.