### PR TITLE
Issue #39 - ASG Strategy: automatically rollback on failures

### DIFF
--- a/lib/cf_deployer/deployment_strategy/auto_scaling_group_swap.rb
+++ b/lib/cf_deployer/deployment_strategy/auto_scaling_group_swap.rb
@@ -35,7 +35,7 @@ module CfDeployer
 
       def swap_group is_switching_to_cooled = false
         is_switching_to_cooled ? warm_up_cooled_stack : warm_up_inactive_stack
-        cool_down_active_stack if active_stack && (is_switching_to_cooled || keep_previous_stack)
+        cool_down(active_stack) if active_stack && (is_switching_to_cooled || keep_previous_stack)
       end
 
       def keep_previous_stack
@@ -56,8 +56,8 @@ module CfDeployer
         warm_up_stack(inactive_stack, active_stack, true)
       end
 
-      def cool_down_active_stack
-        get_active_asgs(active_stack).each do |id|
+      def cool_down stack
+        get_active_asgs(stack).each do |id|
           asg_driver(id).cool_down
         end
       end

--- a/lib/cf_deployer/deployment_strategy/auto_scaling_group_swap.rb
+++ b/lib/cf_deployer/deployment_strategy/auto_scaling_group_swap.rb
@@ -19,8 +19,8 @@ module CfDeployer
         delete_stack inactive_stack
         cool_inactive_on_failure do
           create_inactive_stack
+          swap_group
         end
-        swap_group
         run_hook(:'after-swap')
         Log.info "Active stack has been set to #{inactive_stack.name}"
         delete_stack(active_stack) if active_stack && !keep_previous_stack

--- a/lib/cf_deployer/deployment_strategy/auto_scaling_group_swap.rb
+++ b/lib/cf_deployer/deployment_strategy/auto_scaling_group_swap.rb
@@ -36,7 +36,7 @@ module CfDeployer
       def switch
         check_blue_green_not_both_active 'Switch'
         raise ApplicationError.new('Only one color stack exists, cannot switch to a non-existent version!') unless both_stacks_exist?
-        swap_group true
+        cool_inactive_on_failure { swap_group true }
       end
 
       private

--- a/lib/cf_deployer/logger.rb
+++ b/lib/cf_deployer/logger.rb
@@ -11,6 +11,10 @@ module CfDeployer
       log.info message
     end
 
+    def self.error(message)
+      log.error message
+    end
+
     def self.log
       return @log if @log
       @log = Logger.new('cf_deployer')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,15 @@ Dir.glob("#{File.dirname File.absolute_path(__FILE__)}/fakes/*.rb") { |file| req
 
 CfDeployer::Log.log.outputters = nil
 
+RSPEC_LOG = Logger.new(STDOUT)
+RSPEC_LOG.level = Logger::INFO
+
 def puts *args
 
 end
 
+def ignore_errors
+  yield
+rescue => e
+  RSPEC_LOG.debug "Intentionally ignoring error: #{e.message}"
+end

--- a/spec/unit/deployment_strategy/auto_scaling_group_swap_spec.rb
+++ b/spec/unit/deployment_strategy/auto_scaling_group_swap_spec.rb
@@ -350,18 +350,15 @@ describe 'Auto Scaling Group Swap Deployment Strategy' do
     end
   end
 
-  context '#cool_down_active_stack' do
+  context '#cool_down' do
     it 'should cool down only those ASGs which actually exist' do
       blue_stack.live!
-      green_stack.die!
-      allow(CfDeployer::Driver::AutoScalingGroup).to receive(:new).with('greenASG') { green_asg_driver }
       allow(CfDeployer::Driver::AutoScalingGroup).to receive(:new).with('blueASG') { blue_asg_driver }
-      allow(green_asg_driver).to receive(:describe) { {desired: 0, min: 0, max: 0 } }
       allow(blue_asg_driver).to receive(:describe) { {desired: 1, min: 1, max: 3 } }
 
       strategy = CfDeployer::DeploymentStrategy.create(app, env, component, context)
       expect(blue_asg_driver).to receive(:cool_down)
-      strategy.send(:cool_down_active_stack)
+      strategy.send(:cool_down, blue_stack)
     end
   end
 


### PR DESCRIPTION
This is a fix for Issue #39 

When an ASG-based deployment or switch fails, you can sometimes end up with 2 actives stacks.  Having 2 active stacks prevents you from further deployments/switches without manual intervention.  

Instead of forcing the user to manually intervene, on failures, automatically deactivate the (previously) inactive stack.
