### PR TITLE
Issue #50 - ASG Strategy: fix error message in switch to account for no stacks

### DIFF
--- a/lib/cf_deployer/deployment_strategy/auto_scaling_group_swap.rb
+++ b/lib/cf_deployer/deployment_strategy/auto_scaling_group_swap.rb
@@ -35,7 +35,7 @@ module CfDeployer
 
       def switch
         check_blue_green_not_both_active 'Switch'
-        raise ApplicationError.new('Only one color stack exists, cannot switch to a non-existent version!') unless both_stacks_exist?
+        raise ApplicationError.new('Both stacks must exist to switch.') unless both_stacks_exist?
         cool_inactive_on_failure { swap_group true }
       end
 

--- a/spec/unit/deployment_strategy/auto_scaling_group_swap_spec.rb
+++ b/spec/unit/deployment_strategy/auto_scaling_group_swap_spec.rb
@@ -422,10 +422,11 @@ describe 'Auto Scaling Group Swap Deployment Strategy' do
     end
 
     context 'both stacks do not exist' do
+      let(:error) { 'Both stacks must exist to switch.' }
+
       context '(only green exists)' do
         it 'should raise an error' do
           strategy = create_strategy(green: :active, blue: :dead)
-          error = 'Only one color stack exists, cannot switch to a non-existent version!'
 
           expect { strategy.switch }.to raise_error(error)
         end
@@ -434,7 +435,14 @@ describe 'Auto Scaling Group Swap Deployment Strategy' do
       context '(only blue exists)' do
         it 'should raise an error' do
           strategy = create_strategy(green: :dead, blue: :active)
-          error = 'Only one color stack exists, cannot switch to a non-existent version!'
+
+          expect { strategy.switch }.to raise_error(error)
+        end
+      end
+
+      context '(no stack exists)' do
+        it 'should raise an error' do
+          strategy = create_strategy(green: :dead, blue: :dead)
 
           expect { strategy.switch }.to raise_error(error)
         end


### PR DESCRIPTION
Fix for Issue #50.

If there is no stack, the error message on switch does not make sense.  Updating the error message across all scenarios to account for this case.

Note: This builds off of spec updates from Issue #39.  Review this pull request after #39 is accepted, to get the minimal diff necessary for this fix.
