### PR TITLE
Issue 48 - make less calls to AWS during healthy_instance_count

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,12 @@ namespace :spec do
     t.pattern = 'spec/functional/**/*_spec.rb'
   end
 
-  task :all => [:unit, :functional]
+  RSpec::Core::RakeTask.new(:aws_call_count) do |t|
+    t.rspec_opts = RSPEC_OPTS
+    t.pattern = 'spec/aws_call_count/**/*_spec.rb'
+  end
+
+  task :all => [:unit, :functional, :aws_call_count]
 end
 
 task :default  => 'spec:all'

--- a/cf_deployer.gemspec
+++ b/cf_deployer.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry', '~> 0.10.1'
   gem.add_development_dependency 'rspec', '2.14.1'
   gem.add_development_dependency 'rake', '~> 10.3.0'
+  gem.add_development_dependency 'webmock', '~> 2.1.0'
+  gem.add_development_dependency 'vcr', '~> 2.9.3'
 
   gem.files         = `git ls-files`.split($\).reject {|f| f =~ /^samples\// }
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/fixtures/vcr_cassettes/aws_call_count/driver/auto_scaling_group/healthy_instance_count.yml
+++ b/fixtures/vcr_cassettes/aws_call_count/driver/auto_scaling_group/healthy_instance_count.yml
@@ -1,0 +1,243 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://autoscaling.us-east-1.amazonaws.com/
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeAutoScalingGroupsResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n
+        \ <DescribeAutoScalingGroupsResult>\n    <AutoScalingGroups>\n      <member>\n
+        \       <HealthCheckType>ELB</HealthCheckType>\n        <LoadBalancerNames>\n
+        \         <member>myELB</member>\n        </LoadBalancerNames>\n
+        \       <Instances>\n          <member>\n            <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \           <LifecycleState>InService</LifecycleState>\n            <InstanceId>instance1</InstanceId>\n
+        \           <HealthStatus>Healthy</HealthStatus>\n            <ProtectedFromScaleIn>false</ProtectedFromScaleIn>\n
+        \           <AvailabilityZone>us-east-1d</AvailabilityZone>\n          </member>\n
+        \         <member>\n            <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \           <LifecycleState>InService</LifecycleState>\n            <InstanceId>instance2</InstanceId>\n
+        \           <HealthStatus>Healthy</HealthStatus>\n            <ProtectedFromScaleIn>false</ProtectedFromScaleIn>\n
+        \           <AvailabilityZone>us-east-1c</AvailabilityZone>\n          </member>\n
+        \         <member>\n            <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \           <LifecycleState>InService</LifecycleState>\n            <InstanceId>instance3</InstanceId>\n
+        \           <HealthStatus>Healthy</HealthStatus>\n            <ProtectedFromScaleIn>false</ProtectedFromScaleIn>\n
+        \           <AvailabilityZone>us-east-1e</AvailabilityZone>\n          </member>\n
+        \         <member>\n            <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \           <LifecycleState>InService</LifecycleState>\n            <InstanceId>instance4</InstanceId>\n
+        \           <HealthStatus>Healthy</HealthStatus>\n            <ProtectedFromScaleIn>false</ProtectedFromScaleIn>\n
+        \           <AvailabilityZone>us-east-1e</AvailabilityZone>\n          </member>\n
+        \       </Instances>\n        <TerminationPolicies>\n          <member>Default</member>\n
+        \       </TerminationPolicies>\n        <DefaultCooldown>300</DefaultCooldown>\n
+        \       <AutoScalingGroupARN>arn:aws:autoscaling:us-east-1:12345:autoScalingGroup:12345:autoScalingGroupName/myASG</AutoScalingGroupARN>\n
+        \       <EnabledMetrics/>\n        <MaxSize>5</MaxSize>\n        <AvailabilityZones>\n
+        \         <member>us-east-1c</member>\n          <member>us-east-1d</member>\n
+        \         <member>us-east-1e</member>\n        </AvailabilityZones>\n        <TargetGroupARNs/>\n
+        \       <Tags/>\n
+        \       <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \       <AutoScalingGroupName>myASG</AutoScalingGroupName>\n
+        \       <HealthCheckGracePeriod>600</HealthCheckGracePeriod>\n        <NewInstancesProtectedFromScaleIn>false</NewInstancesProtectedFromScaleIn>\n
+        \       <CreatedTime>2016-09-23T03:52:21.733Z</CreatedTime>\n        <MinSize>1</MinSize>\n
+        \       <SuspendedProcesses/>\n        <DesiredCapacity>4</DesiredCapacity>\n
+        \       <VPCZoneIdentifier>subnet</VPCZoneIdentifier>\n
+        \     </member>\n    </AutoScalingGroups>\n  </DescribeAutoScalingGroupsResult>\n
+        \ <ResponseMetadata>\n    <RequestId>12345</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeAutoScalingGroupsResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:40 GMT
+- request:
+    method: post
+    uri: https://autoscaling.us-east-1.amazonaws.com/
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeAutoScalingInstancesResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n
+        \ <DescribeAutoScalingInstancesResult>\n    <AutoScalingInstances>\n      <member>\n
+        \       <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \       <LifecycleState>InService</LifecycleState>\n        <AutoScalingGroupName></AutoScalingGroupName>\n
+        \       <InstanceId>instance1</InstanceId>\n        <HealthStatus>HEALTHY</HealthStatus>\n
+        \       <ProtectedFromScaleIn>false</ProtectedFromScaleIn>\n        <AvailabilityZone>us-east-1d</AvailabilityZone>\n
+        \     </member>\n    </AutoScalingInstances>\n  </DescribeAutoScalingInstancesResult>\n
+        \ <ResponseMetadata>\n    <RequestId>12346</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeAutoScalingInstancesResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:40 GMT
+- request:
+    method: post
+    uri: https://elasticloadbalancing.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeInstanceHealth&LoadBalancerName=myELB&Timestamp=2016-09-27T05%3A47%3A41Z&Version=2012-06-01
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeInstanceHealthResponse xmlns=\"http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/\">\n
+        \ <DescribeInstanceHealthResult>\n    <InstanceStates>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance1</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance2</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance3</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance4</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n    </InstanceStates>\n
+        \ </DescribeInstanceHealthResult>\n  <ResponseMetadata>\n    <RequestId>12347</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeInstanceHealthResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:41 GMT
+- request:
+    method: post
+    uri: https://autoscaling.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeAutoScalingInstances&InstanceIds.member.1=instance2&Timestamp=2016-09-27T05%3A47%3A41Z&Version=2011-01-01
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeAutoScalingInstancesResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n
+        \ <DescribeAutoScalingInstancesResult>\n    <AutoScalingInstances>\n      <member>\n
+        \       <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \       <LifecycleState>InService</LifecycleState>\n        <AutoScalingGroupName>myASG</AutoScalingGroupName>\n
+        \       <InstanceId>instance2</InstanceId>\n        <HealthStatus>HEALTHY</HealthStatus>\n
+        \       <ProtectedFromScaleIn>false</ProtectedFromScaleIn>\n        <AvailabilityZone>us-east-1c</AvailabilityZone>\n
+        \     </member>\n    </AutoScalingInstances>\n  </DescribeAutoScalingInstancesResult>\n
+        \ <ResponseMetadata>\n    <RequestId>12348</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeAutoScalingInstancesResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:42 GMT
+- request:
+    method: post
+    uri: https://elasticloadbalancing.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeInstanceHealth&LoadBalancerName=myELB&Timestamp=2016-09-27T05%3A47%3A42Z&Version=2012-06-01
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeInstanceHealthResponse xmlns=\"http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/\">\n
+        \ <DescribeInstanceHealthResult>\n    <InstanceStates>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance1</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance2</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance3</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance4</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n    </InstanceStates>\n
+        \ </DescribeInstanceHealthResult>\n  <ResponseMetadata>\n    <RequestId>12349</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeInstanceHealthResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:42 GMT
+- request:
+    method: post
+    uri: https://autoscaling.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeAutoScalingInstances&InstanceIds.member.1=instance3&Timestamp=2016-09-27T05%3A47%3A42Z&Version=2011-01-01
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeAutoScalingInstancesResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n
+        \ <DescribeAutoScalingInstancesResult>\n    <AutoScalingInstances>\n      <member>\n
+        \       <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \       <LifecycleState>InService</LifecycleState>\n        <AutoScalingGroupName>myASG</AutoScalingGroupName>\n
+        \       <InstanceId>instance3</InstanceId>\n        <HealthStatus>HEALTHY</HealthStatus>\n
+        \       <ProtectedFromScaleIn>false</ProtectedFromScaleIn>\n        <AvailabilityZone>us-east-1e</AvailabilityZone>\n
+        \     </member>\n    </AutoScalingInstances>\n  </DescribeAutoScalingInstancesResult>\n
+        \ <ResponseMetadata>\n    <RequestId>12350</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeAutoScalingInstancesResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:42 GMT
+- request:
+    method: post
+    uri: https://elasticloadbalancing.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeInstanceHealth&LoadBalancerName=myELB&Timestamp=2016-09-27T05%3A47%3A42Z&Version=2012-06-01
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeInstanceHealthResponse xmlns=\"http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/\">\n
+        \ <DescribeInstanceHealthResult>\n    <InstanceStates>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance1</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance2</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance3</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance4</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n    </InstanceStates>\n
+        \ </DescribeInstanceHealthResult>\n  <ResponseMetadata>\n    <RequestId>12351</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeInstanceHealthResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:42 GMT
+- request:
+    method: post
+    uri: https://autoscaling.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeAutoScalingInstances&InstanceIds.member.1=instance4&Timestamp=2016-09-27T05%3A47%3A42Z&Version=2011-01-01
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeAutoScalingInstancesResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n
+        \ <DescribeAutoScalingInstancesResult>\n    <AutoScalingInstances>\n      <member>\n
+        \       <LaunchConfigurationName>myLaunchConfig</LaunchConfigurationName>\n
+        \       <LifecycleState>InService</LifecycleState>\n        <AutoScalingGroupName>myASG</AutoScalingGroupName>\n
+        \       <InstanceId>instance4</InstanceId>\n        <HealthStatus>HEALTHY</HealthStatus>\n
+        \       <ProtectedFromScaleIn>false</ProtectedFromScaleIn>\n        <AvailabilityZone>us-east-1e</AvailabilityZone>\n
+        \     </member>\n    </AutoScalingInstances>\n  </DescribeAutoScalingInstancesResult>\n
+        \ <ResponseMetadata>\n    <RequestId>12352</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeAutoScalingInstancesResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:42 GMT
+- request:
+    method: post
+    uri: https://elasticloadbalancing.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeInstanceHealth&LoadBalancerName=myELB&Timestamp=2016-09-27T05%3A47%3A42Z&Version=2012-06-01
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: US-ASCII
+      string: ! "<DescribeInstanceHealthResponse xmlns=\"http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/\">\n
+        \ <DescribeInstanceHealthResult>\n    <InstanceStates>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance1</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance2</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance3</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n      <member>\n        <Description>N/A</Description>\n
+        \       <InstanceId>instance4</InstanceId>\n        <ReasonCode>N/A</ReasonCode>\n
+        \       <State>InService</State>\n      </member>\n    </InstanceStates>\n
+        \ </DescribeInstanceHealthResult>\n  <ResponseMetadata>\n    <RequestId>12353</RequestId>\n
+        \ </ResponseMetadata>\n</DescribeInstanceHealthResponse>\n"
+    http_version: 
+  recorded_at: Tue, 27 Sep 2016 05:47:42 GMT
+recorded_with: VCR 2.9.3

--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -62,28 +62,41 @@ module CfDeployer
         healthy_instance_count >= desired_capacity
       end
 
-      private
+      def healthy_instance_ids
+        instances = auto_scaling_instances.select do |instance|
+          instance.health_status == 'HEALTHY'
+        end
+        instances.map(&:id)
+      end
+
+      def in_service_instance_ids
+        elbs = load_balancers
+        return [] if elbs.empty?
+
+        ids = elbs.collect(&:instances)
+                  .collect(&:health)
+                  .to_a
+                  .collect { |elb_healths|
+                     elb_healths.select { |health| health[:state] == 'InService' }
+                                .map { |health| health[:instance].id }
+                  }
+
+        ids.inject(:&)
+      end
 
       def healthy_instance_count
         begin
-          count = auto_scaling_instances.count do |instance|
-            instance.health_status == 'HEALTHY' && (load_balancers.empty? || instance_in_service?( instance.ec2_instance ))
-          end
-          Log.info "Healthy instance count: #{count}"
-          count
+          instances = healthy_instance_ids
+          instances &= in_service_instance_ids unless load_balancers.empty?
+          Log.info "Healthy instance count: #{instances.count}"
+          instances.count
         rescue => e
           Log.info "Unable to determine healthy instance count due to error: #{e.message}"
           -1
         end
       end
 
-      def instance_in_service? instance
-        load_balancers.all? do |load_balancer|
-          load_balancer.instances.health.any? do |health|
-            health[:instance] == instance ? health[:state] == 'InService' : false
-          end
-        end
-      end
+      private
 
       def aws_group
         @my_group ||= AWS::AutoScaling.new.groups[group_name]

--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -92,7 +92,7 @@ module CfDeployer
           instances.count
         end
       rescue => e
-        Log.info "Unable to determine healthy instance count due to error: #{e.message}"
+        Log.error "Unable to determine healthy instance count due to error: #{e.message}"
         -1
       end
 

--- a/lib/cf_deployer/driver/auto_scaling_group.rb
+++ b/lib/cf_deployer/driver/auto_scaling_group.rb
@@ -64,7 +64,7 @@ module CfDeployer
 
       def healthy_instance_ids
         instances = auto_scaling_instances.select do |instance|
-          instance.health_status == 'HEALTHY'
+          'HEALTHY'.casecmp(instance.health_status) == 0
         end
         instances.map(&:id)
       end
@@ -85,15 +85,15 @@ module CfDeployer
       end
 
       def healthy_instance_count
-        begin
+        AWS.memoize do
           instances = healthy_instance_ids
           instances &= in_service_instance_ids unless load_balancers.empty?
           Log.info "Healthy instance count: #{instances.count}"
           instances.count
-        rescue => e
-          Log.info "Unable to determine healthy instance count due to error: #{e.message}"
-          -1
         end
+      rescue => e
+        Log.info "Unable to determine healthy instance count due to error: #{e.message}"
+        -1
       end
 
       private

--- a/spec/aws_call_count/driver/auto_scaling_group_spec.rb
+++ b/spec/aws_call_count/driver/auto_scaling_group_spec.rb
@@ -1,0 +1,19 @@
+require 'aws_call_count_spec_helper'
+
+describe CfDeployer::Driver::AutoScalingGroup do
+  it 'makes the minimum number of calls to AWS when there are 4 instances in the ASG' do
+    asg = 'myASG'
+
+    override_aws_environment(AWS_REGION: 'us-east-1') do
+      logs = nil
+      allow(CfDeployer::Log).to receive(:info) { |message| logs = message }
+      driver = CfDeployer::Driver::AutoScalingGroup.new asg
+      VCR.use_cassette("aws_call_count/driver/auto_scaling_group/healthy_instance_count") do
+        expect(driver.send(:healthy_instance_count)).to equal(4), "Logs: #{logs}"
+      end
+
+      expect(WebMock).to have_requested(:post, "https://autoscaling.us-east-1.amazonaws.com/").times(5)
+      expect(WebMock).to have_requested(:post, "https://elasticloadbalancing.us-east-1.amazonaws.com/").times(4)
+    end
+  end
+end

--- a/spec/aws_call_count/driver/auto_scaling_group_spec.rb
+++ b/spec/aws_call_count/driver/auto_scaling_group_spec.rb
@@ -12,7 +12,7 @@ describe CfDeployer::Driver::AutoScalingGroup do
         expect(driver.send(:healthy_instance_count)).to equal(4), "Logs: #{logs}"
       end
 
-      expect(WebMock).to have_requested(:post, "https://autoscaling.us-east-1.amazonaws.com/").times(5)
+      expect(WebMock).to have_requested(:post, "https://autoscaling.us-east-1.amazonaws.com/").times(1)
       expect(WebMock).to have_requested(:post, "https://elasticloadbalancing.us-east-1.amazonaws.com/").times(1)
     end
   end

--- a/spec/aws_call_count/driver/auto_scaling_group_spec.rb
+++ b/spec/aws_call_count/driver/auto_scaling_group_spec.rb
@@ -6,7 +6,7 @@ describe CfDeployer::Driver::AutoScalingGroup do
 
     override_aws_environment(AWS_REGION: 'us-east-1') do
       logs = nil
-      allow(CfDeployer::Log).to receive(:info) { |message| logs = message }
+      allow(CfDeployer::Log).to receive(:error) { |message| logs = message }
       driver = CfDeployer::Driver::AutoScalingGroup.new asg
       VCR.use_cassette("aws_call_count/driver/auto_scaling_group/healthy_instance_count") do
         expect(driver.send(:healthy_instance_count)).to equal(4), "Logs: #{logs}"

--- a/spec/aws_call_count/driver/auto_scaling_group_spec.rb
+++ b/spec/aws_call_count/driver/auto_scaling_group_spec.rb
@@ -13,7 +13,7 @@ describe CfDeployer::Driver::AutoScalingGroup do
       end
 
       expect(WebMock).to have_requested(:post, "https://autoscaling.us-east-1.amazonaws.com/").times(5)
-      expect(WebMock).to have_requested(:post, "https://elasticloadbalancing.us-east-1.amazonaws.com/").times(4)
+      expect(WebMock).to have_requested(:post, "https://elasticloadbalancing.us-east-1.amazonaws.com/").times(1)
     end
   end
 end

--- a/spec/aws_call_count_spec_helper.rb
+++ b/spec/aws_call_count_spec_helper.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end
+
+def override_aws_environment options = {}
+  options[:AWS_REGION] ||= 'us-east-1'
+  options[:AWS_ACCESS_KEY_ID] ||= 'someId'
+  options[:AWS_SECRET_ACCESS_KEY] ||= 'secretKey'
+
+  override_environment_variables(options) { yield }
+end
+
+def override_environment_variables options = {}
+  previous_values = override_previous_values(options)
+
+  yield
+
+  restore_values(previous_values)
+end
+
+def override_previous_values options = {}
+  previous_values = options.inject([]) do |memo, (key,value)|
+    memo << { key: key.to_s, value: value, existed: ENV.has_key?(key.to_s), old_value: ENV[key.to_s] }
+    ENV[key.to_s] = value
+    memo
+  end
+end
+
+def restore_values previous_values = []
+  previous_values.each do |value|
+    value[:existed] ? ENV[value[:key]] = value[:old_value] : ENV.delete(value[:key])
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,12 @@ Dir.glob("#{File.dirname File.absolute_path(__FILE__)}/fakes/*.rb") { |file| req
 CfDeployer::Log.log.outputters = nil
 
 RSPEC_LOG = Logger.new(STDOUT)
-RSPEC_LOG.level = Logger::INFO
+RSPEC_LOG.level = Logger::WARN
+
+if ENV['DEBUG']
+  RSPEC_LOG.level = Logger::DEBUG
+  AWS.config :logger => RSPEC_LOG
+end
 
 def puts *args
 

--- a/spec/unit/driver/auto_scaling_group_spec.rb
+++ b/spec/unit/driver/auto_scaling_group_spec.rb
@@ -61,6 +61,13 @@ describe 'Autoscaling group driver' do
 
       expect(@driver.healthy_instance_ids).to eql ['instance1', 'instance2', 'instance4']
     end
+
+    it 'returns the ids of all instances that are healthy (case insensitive)' do
+      instance1 =  double('instance1', :health_status => 'HealThy', id: 'instance1')
+      allow(group).to receive(:auto_scaling_instances){[instance1]}
+
+      expect(@driver.healthy_instance_ids).to eql ['instance1']
+    end
   end
 
   describe '#in_service_instance_ids' do


### PR DESCRIPTION
This is a fix for Issue #48 

Add a test suite to start tracking the number of calls made to AWS, and execute that test suite by default.  Refactor the healthy_instance_count method to not make N+1 calls to AWS per instance in the elb.
